### PR TITLE
Changed how tls for postgres is configured.

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -65,8 +65,7 @@ public func configure(_ app: Application) async throws {
     app.middleware.use(cors, at: .beginning)
 
 	var tlsConfig: TLSConfiguration = .makeClientConfiguration()
-	// Do not disable certificate verification in production. You should provide a certificate to the TLSConfiguration to verify against
-	tlsConfig.certificateVerification = .none
+	tlsConfig.certificateVerification = .noHostnameVerification		// Use `.noHostnameVerification` if your production env will be using something like nginx. Otherwise change it to `.fullVerification`. Command click to check the full details.
 	let nioSSLContext = try NIOSSLContext(configuration: tlsConfig)
 	
 	let config = SQLPostgresConfiguration(
@@ -75,7 +74,7 @@ public func configure(_ app: Application) async throws {
 		username: Environment.get("DATABASE_USERNAME") ?? "vapor_username",
 		password: Environment.get("DATABASE_PASSWORD") ?? "vapor_password",
 		database: Environment.get("DATABASE_NAME") ?? "vapor_database",
-		tls: .prefer(nioSSLContext)
+		tls: app.environment == .production ? .require(nioSSLContext) : .disable
 	)
 	let postgres = DatabaseConfigurationFactory.postgres(configuration: config)
 	app.databases.use(postgres, as: .psql)

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -65,7 +65,8 @@ public func configure(_ app: Application) async throws {
     app.middleware.use(cors, at: .beginning)
 
 	var tlsConfig: TLSConfiguration = .makeClientConfiguration()
-	tlsConfig.certificateVerification = .noHostnameVerification		// Use `.noHostnameVerification` if your production env will be using something like nginx. Otherwise change it to `.fullVerification`. Command click to check the full details.
+	// Check if you can increase the security by performing a certificate verification based on your database setup
+	tlsConfig.certificateVerification = .none
 	let nioSSLContext = try NIOSSLContext(configuration: tlsConfig)
 	
 	let config = SQLPostgresConfiguration(


### PR DESCRIPTION
New implementation silences xCode warnings by replacing the deprecated function.
According to documentation, `TLS.prefer(_ sslContext: NIOSSLContext)` will Try to create a TLS connection to the server. If the server supports TLS, create a TLS connection. If the server does not support TLS, create an insecure connection. 

This fix makes sure app is able to build and run if TLS is not configured properly.